### PR TITLE
Add vue-use-switch-map && vue-use-infinite-scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 - [vue-use-kit](https://github.com/microcipcip/vue-use-kit) - 🛠️ Useful collection of Vue composition API functions
 - [vue-condition-watcher](https://github.com/runkids/vue-condition-watcher) - 🕶 Vue Composition API for automatic fetch data when condition has been changed
 - [vue-use](https://github.com/openfext/vue-use) - ✨ Use magic Vue Composition APIs to provide a lot of reusable logic, such as form, table and loading, etc.
+- [vue-use-switch-map](https://github.com/jfet97/vue-use-switch-map) - 👽 The power of the RxJS switchMap operator brought to the Vue composition world
 
 ## 🔧 Tools / Helper libraries
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - [vue-condition-watcher](https://github.com/runkids/vue-condition-watcher) - 🕶 Vue Composition API for automatic fetch data when condition has been changed
 - [vue-use](https://github.com/openfext/vue-use) - ✨ Use magic Vue Composition APIs to provide a lot of reusable logic, such as form, table and loading, etc.
 - [vue-use-switch-map](https://github.com/jfet97/vue-use-switch-map) - 👽 The power of the RxJS switchMap operator injected into the Vue composition world
+- [vue-use-infinite-scroll](https://github.com/jfet97/vue-use-infinite-scroll) - ♾️ A Vue composition function that makes infinite scroll a breeze
 
 ## 🔧 Tools / Helper libraries
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - [vue-use-kit](https://github.com/microcipcip/vue-use-kit) - 🛠️ Useful collection of Vue composition API functions
 - [vue-condition-watcher](https://github.com/runkids/vue-condition-watcher) - 🕶 Vue Composition API for automatic fetch data when condition has been changed
 - [vue-use](https://github.com/openfext/vue-use) - ✨ Use magic Vue Composition APIs to provide a lot of reusable logic, such as form, table and loading, etc.
-- [vue-use-switch-map](https://github.com/jfet97/vue-use-switch-map) - 👽 The power of the RxJS switchMap operator injected to the Vue composition world
+- [vue-use-switch-map](https://github.com/jfet97/vue-use-switch-map) - 👽 The power of the RxJS switchMap operator injected into the Vue composition world
 
 ## 🔧 Tools / Helper libraries
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 - [vue-use-kit](https://github.com/microcipcip/vue-use-kit) - 🛠️ Useful collection of Vue composition API functions
 - [vue-condition-watcher](https://github.com/runkids/vue-condition-watcher) - 🕶 Vue Composition API for automatic fetch data when condition has been changed
 - [vue-use](https://github.com/openfext/vue-use) - ✨ Use magic Vue Composition APIs to provide a lot of reusable logic, such as form, table and loading, etc.
-- [vue-use-switch-map](https://github.com/jfet97/vue-use-switch-map) - 👽 The power of the RxJS switchMap operator brought to the Vue composition world
+- [vue-use-switch-map](https://github.com/jfet97/vue-use-switch-map) - 👽 The power of the RxJS switchMap operator injected to the Vue composition world
 
 ## 🔧 Tools / Helper libraries
 


### PR DESCRIPTION
This package is designed for binding refs to Vue composition functions, which, in turn, may produce one or more refs.
The behaviour is similar to the RxJS switchMap operator.